### PR TITLE
Fix bug at image deployment

### DIFF
--- a/src/main/java/at/uibk/dps/ee/docker/manager/ContainerManagerDockerAPI.java
+++ b/src/main/java/at/uibk/dps/ee/docker/manager/ContainerManagerDockerAPI.java
@@ -156,6 +156,15 @@ public class ContainerManagerDockerAPI implements ContainerManager {
 
   @Override
   public void initImage(String imageName) {
+    this.client.listContainersCmd().exec()
+      .forEach(c -> logger.info("Already running: " + c.getImage()));
+
+    if (this.client.listContainersCmd().exec().stream()
+      .anyMatch(c -> c.getImage().equals(imageName))) {
+      // Return if an image is already running.
+      return;
+    }
+
     this.pullImage(imageName);
 
     final int port = 8800 + functions.size();


### PR DESCRIPTION
Running the same function multiple times in a workflow, would start a function image more than once, resulting in an error that the function is already running.
Fixed by implementing a check the ContainerManager.